### PR TITLE
add section on transfering files to the cluster with git

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,9 +19,11 @@ title: High Performance Computing
 
 2.  Transferring files to/from the cluster (20-30 min)
 
-    a.  Filezilla and scp (macs only)
+    a.  Synchronizing local and cluster directories with git 
 
-    b.  **Activity:** transferring files to/from cluster
+    b.  Filezilla and scp for large static files
+
+    c.  **Activity:** transferring files to/from cluster
 
 3.  Queues and partitions/allocations (30 min)
 


### PR DESCRIPTION
Since we already teach git, it makes sense to me to use this as the file transfer mechanism. The downside is that we probably have to explain that git is not good for (e.g.) a 200 Gb folder of image files, so we need to cover scp (rsync?) for that anyway. I think this is outweighed by the opportunity to reinforce the previous lesson on git.
