### PR TITLE
removed mpi and added more examples

### DIFF
--- a/_episodes/10-parallel-tasks.md
+++ b/_episodes/10-parallel-tasks.md
@@ -4,8 +4,8 @@ questions:
 - "How can you run many jobs at once?"
 ---
 
-Describe how to submit parallel tasks (and why)
+Describe how to submit parallel tasks (and why), e.g. running multiple jobs on a given data set (1 job per file)
 
-Exercise: submit parallel jobs using the shell script (minus for loop) from the shell section
+Exercise: submit parallel jobs using the shell script (without a for loop) from the shell section
 
 Exercise: PI estimation example

--- a/_episodes/11-parallel-code.md
+++ b/_episodes/11-parallel-code.md
@@ -8,10 +8,8 @@ questions:
 
 Topics: 
 
-MPI or scientific program example
+scientific program example (2D heat conduction, pi estimate, map-reduce of some simple statistics problem)
 
-Talk generally about setting a threads option or using mpirun, give a few examples
+Talk generally about setting a threads option, give a few examples
 
-Exercise: run an MPI-enabled program
-
-Exercise: run an SMP program
+Exercise: run a prepared SMP program


### PR DESCRIPTION
I think anything related to MPI should go into `hpc-parallel`. Touching on it just attracts more questions than you may want to have in this material. I believe for real novices discussing a shared memory application can be (on average) challenging. 

I'd rather suggest to focus discussions of how to parallelize, when and with that technology into `hpc-parallel` and then allow the sites to mix and match.